### PR TITLE
Add selecting-licenses.html to ToC menu

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -39,6 +39,8 @@ getting-started:
         url: /getting-started/archiving.html
       - page: Publishing
         url: /getting-started/publishing.html
+      - page: Data Licensing
+        url: /getting-started/selecting-license.html
       - page: Notifications
         url: /getting-started/notification-settings.html
   - page: The Yoda network drive


### PR DESCRIPTION
Adding this to the menu.yml so that it's easier to find the selecting licenses page without having to know the URL off the top of your head. There are no other links to it that I can see